### PR TITLE
Add hardcoded country/country code to addresses

### DIFF
--- a/Geopunt.php
+++ b/Geopunt.php
@@ -84,6 +84,8 @@ final class Geopunt extends AbstractHttpProvider implements Provider
                 ->setStreetName($streetName)
                 ->setLocality($municipality)
                 ->setPostalCode($zipcode)
+                ->setCountry('België')
+                ->setCountryCode('BE')
                 ->setBounds(
                     $location->BoundingBox->LowerLeft->Lat_WGS84,
                     $location->BoundingBox->LowerLeft->Lon_WGS84,
@@ -125,6 +127,8 @@ final class Geopunt extends AbstractHttpProvider implements Provider
                 ->setStreetName($streetName)
                 ->setLocality($municipality)
                 ->setPostalCode($zipcode)
+                ->setCountry('België')
+                ->setCountryCode('BE')
                 ->setBounds(
                     $location->BoundingBox->LowerLeft->Lat_WGS84,
                     $location->BoundingBox->LowerLeft->Lon_WGS84,


### PR DESCRIPTION
When using the StringFormatter class to format addresses returned by this provider, the country is empty. Since this provider only works with Belgian addresses, we should add the country hardcoded to every address so it can be used when formatting.