### PR TITLE
Add support for Geocoder 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "geocoder-php/common-http": "^4.0",
-        "willdurand/geocoder": "^4.0"
+        "willdurand/geocoder": "^4.0 || ^5.0"
     },
     "provide": {
         "geocoder-php/provider-implementation": "1.0"


### PR DESCRIPTION
## Problem

The package only supports Geocoder 4.x versions.
The Geocoder 5.x version fixed PHP 8.4 deprecations.

## Solution

Add support for 5.x in composer.json.